### PR TITLE
add method to update topic status

### DIFF
--- a/models/topics.js
+++ b/models/topics.js
@@ -5,6 +5,7 @@
 module.exports = api => ({
   get: id => api.authGet(`/t/${id}.json`)(),
   update: t => api.authPut(`/t/${t.slug}/${t.id}.json`)(t),
+  updateStatus: (topicId, status) => api.authPut(`/t/${topicId}/status`)({ status, enabled: true }),
   getPostId: ({
     post_stream: {
       posts: [{ id }],


### PR DESCRIPTION
**What:** add method to update topic status. https://docs.discourse.org/#tag/Topics/paths/~1t~1{id}~1status/put

**Why:** This will allow us to close topics using the API. Related to https://github.com/debtcollective/dispute-tools/pull/195

**How:**

- Add `topics.updateStatus` method 
