### PR TITLE
Fix integration for messages endpoint

### DIFF
--- a/models/admin/messages.js
+++ b/models/admin/messages.js
@@ -18,7 +18,8 @@ const message = api =>
         raw,
         unlist_topic,
         is_warning,
-        archetype,
+        archetype:
+          topic_id && archetype === "private_message" ? "regular" : archetype,
         nested_post,
         typing_duration_msecs,
         composer_duration_open_msecs,

--- a/models/admin/messages.js
+++ b/models/admin/messages.js
@@ -1,16 +1,16 @@
 const message = api =>
   class Message {
     constructor({
-      target_usernames,
+      target_recipients,
       raw,
       title,
       topic_id = null,
       unlist_topic = false,
       is_warning = false,
-      archetype = 'private_message',
+      archetype = "private_message",
       nested_post = true,
       typing_duration_msecs = 1,
-      composer_duration_open_msecs = 1,
+      composer_duration_open_msecs = 1
     }) {
       this._api = api;
 
@@ -22,12 +22,12 @@ const message = api =>
         nested_post,
         typing_duration_msecs,
         composer_duration_open_msecs,
-        ...(topic_id !== null ? { topic_id } : { target_usernames, title }),
+        ...(topic_id !== null ? { topic_id } : { target_recipients, title })
       };
     }
 
     send() {
-      return this._api.authPost('/posts')({ ...this._formData });
+      return this._api.authPost("/posts")({ ...this._formData });
     }
   };
 
@@ -35,6 +35,6 @@ module.exports = api => {
   const Message = message(api);
   return {
     Message,
-    create: config => new Message(config).send(),
+    create: config => new Message(config).send()
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discourse-node-api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Node.js API for Discourse's REST API",
   "main": "index.js",
   "repository": "https://github.com/debtcollective/discourse-node-api",

--- a/test/messages.test.js
+++ b/test/messages.test.js
@@ -1,32 +1,56 @@
-const { expect } = require('chai');
-const { mockApi } = require('./fixtures');
+const { expect } = require("chai");
+const { mockApi } = require("./fixtures");
 
-const messages = require('../models/admin/messages')(mockApi);
+const messages = require("../models/admin/messages")(mockApi);
 
-describe('messages', () => {
-  describe('constructor', () => {
-    describe('_formData', () => {
-      describe('topic_id is null', () => {
-        it('should set the title and the target usernames', () => {
-          const target_usernames = ['a', 'b'];
-          const title = 'a fake title';
-          const m = new messages.Message({ target_usernames, title, topic_id: null });
-          expect(m._formData.target_usernames).eq(target_usernames);
+describe("messages", () => {
+  describe("constructor", () => {
+    describe("_formData", () => {
+      describe("topic_id is null", () => {
+        it("should set the title and the target recipients", () => {
+          const target_recipients = ["a", "b"];
+          const title = "a fake title";
+          const m = new messages.Message({
+            target_recipients,
+            title,
+            topic_id: null
+          });
+          expect(m._formData.target_recipients).eq(target_recipients);
           expect(m._formData.title).eq(title);
           expect(m._formData.topic_id).undefined;
         });
       });
 
-      describe('topic_id not null', () => {
-        it('should set the topic_id and not the target usernames', () => {
-          const target_usernames = ['1', '2'];
-          const title = 'a fake title';
+      describe("topic_id not null", () => {
+        it("should set the topic_id and not the target recipients", () => {
+          const target_recipients = ["1", "2"];
+          const title = "a fake title";
           const topic_id = 1234;
-          const m = new messages.Message({ target_usernames, title, topic_id });
+          const m = new messages.Message({
+            target_recipients,
+            title,
+            topic_id
+          });
 
           expect(m._formData.topic_id).eq(topic_id);
-          expect(m._formData.target_usernames).undefined;
+          expect(m._formData.target_recipients).undefined;
           expect(m._formData.title).undefined;
+        });
+
+        it("should set the archetype to `regular` if `private_message` is passed", () => {
+          const target_recipients = ["1", "2"];
+          const title = "a fake title";
+          const topic_id = 1234;
+          const m = new messages.Message({
+            target_recipients,
+            title,
+            topic_id
+          });
+
+          expect(m._formData.topic_id).eq(topic_id);
+          expect(m._formData.target_recipients).undefined;
+          expect(m._formData.title).undefined;
+          expect(m._formData.archetype).eq("regular");
         });
       });
     });


### PR DESCRIPTION
**What:** Fix integration for messages endpoint.

**Why:** Discourse made a breaking change on how private messages are created. Here's more info about it https://meta.discourse.org/t/quick-messages-plugin/39188/428

Closes https://app.asana.com/0/1168997577035609/1179448257485197 and https://app.asana.com/0/1168997577035609/1178339208108249

**How:**

- Only pass `archetype='private_message'` when we are creating the private message topic. To add posts to this topic we need to pass `archetype='regular'`
- Replace deprecated `target_usernames` param in favor of `target_recipients`